### PR TITLE
Split payments

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 jobs:
-  release-relay:
+  upload-docker-images:
     name: ECR push
     runs-on: ubuntu-latest
     environment: production

--- a/README.md
+++ b/README.md
@@ -109,7 +109,11 @@ Alternatively you can also use the [Alby simnetwork](https://github.com/getAlby/
 
 ## Database
 
-LndHub.go requires a PostgreSQL database backend.
+LndHub.go requires a PostgreSQL database backend. In order to run the golang unitary test, 
+one can run a local database like this:
+```shell
+docker run -d --rm --name posgres -e POSTGRES_USER=user -e POSTGRES_PASSWORD=password -e POSTGRES_DB=lndhub -v $(pwd)/dbdata:/var/lib/postgresql/data --network=host postgres
+```
 
 ## Prometheus
 

--- a/common/globals.go
+++ b/common/globals.go
@@ -1,10 +1,11 @@
 package common
 
 const (
-	InvoiceTypeOutgoing = "outgoing"
-	InvoiceTypePaid     = "paid_invoice"
-	InvoiceTypeIncoming = "incoming"
-	InvoiceTypeUser     = "user_invoice"
+	InvoiceTypeOutgoing   = "outgoing"
+	InvoiceTypePaid       = "paid_invoice"
+	InvoiceTypeIncoming   = "incoming"
+	InvoiceTypeUser       = "user_invoice"
+	InvoiceTypeSubinvoice = "sub_invoice"
 
 	InvoiceStateSettled     = "settled"
 	InvoiceStateInitialized = "initialized"

--- a/controllers/gettxs.ctrl.go
+++ b/controllers/gettxs.ctrl.go
@@ -76,7 +76,7 @@ func (controller *GetTXSController) GetTXS(c echo.Context) error {
 func (controller *GetTXSController) GetUserInvoices(c echo.Context) error {
 	userId := c.Get("UserID").(int64)
 
-	invoices, err := controller.svc.InvoicesFor(c.Request().Context(), userId, common.InvoiceTypeIncoming)
+	invoices, err := controller.svc.InvoicesIncomingAndInternalFor(c.Request().Context(), userId)
 	if err != nil {
 		return err
 	}

--- a/controllers/payinvoice.ctrl.go
+++ b/controllers/payinvoice.ctrl.go
@@ -57,7 +57,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 	paymentRequest = strings.ToLower(paymentRequest)
 	decodedPaymentRequest, err := controller.svc.DecodePaymentRequest(c.Request().Context(), paymentRequest)
 	if err != nil {
-		if strings.Contains(err.Error(),"invoice not for current active network") {
+		if strings.Contains(err.Error(), "invoice not for current active network") {
 			c.Logger().Errorf("Incorrect network user_id:%v error: %v", userID, err)
 			return c.JSON(http.StatusBadRequest, responses.IncorrectNetworkError)
 		}

--- a/controllers/payinvoice.ctrl.go
+++ b/controllers/payinvoice.ctrl.go
@@ -69,7 +69,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 		PayReq:  decodedPaymentRequest,
 		Keysend: false,
 	}
-	if (decodedPaymentRequest.Timestamp + decodedPaymentRequest.Expiry) < time.Now().Unix() {
+	if (decodedPaymentRequest.Timestamp + decodedPaymentRequest.Expiry/int64(time.Second)) < time.Now().Unix() {
 		c.Logger().Errorf("Payment request expired")
 		return c.JSON(http.StatusBadRequest, responses.InvoiceExpiredError)
 	}

--- a/controllers/payinvoice.ctrl.go
+++ b/controllers/payinvoice.ctrl.go
@@ -69,7 +69,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 		PayReq:  decodedPaymentRequest,
 		Keysend: false,
 	}
-	if (decodedPaymentRequest.Timestamp + decodedPaymentRequest.Expiry/int64(time.Second)) < time.Now().Unix() {
+	if (decodedPaymentRequest.Timestamp + decodedPaymentRequest.Expiry) < time.Now().Unix() {
 		c.Logger().Errorf("Payment request expired")
 		return c.JSON(http.StatusBadRequest, responses.InvoiceExpiredError)
 	}

--- a/controllers_v2/invoice.ctrl.go
+++ b/controllers_v2/invoice.ctrl.go
@@ -1,12 +1,8 @@
 package v2controllers
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
+	"fmt"
 	"net/http"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/getAlby/lndhub.go/common"
@@ -135,6 +131,8 @@ type AddInvoiceRequestBody struct {
 	DescriptionHash string `json:"description_hash" validate:"omitempty,hexadecimal,len=64"`
 }
 
+// AddInvoiceResponseBody kept because some clients use this
+// strunct rather than the lndhub lud6 one.
 type AddInvoiceResponseBody struct {
 	PaymentHash    string    `json:"payment_hash"`
 	PaymentRequest string    `json:"payment_request"`
@@ -145,14 +143,32 @@ type GetInvoicesResponseBody struct {
 	Invoices []Invoice `json:"invoices"`
 }
 
-type InvoiceResponseBody struct {
+// Lud6InvoiceResponseBody must comply with lud6
+// https://github.com/lnurl/luds/blob/luds/06.md
+type Lud6InvoiceResponseBody struct {
 	Payreq string   `json:"pr"`
 	Routes []string `json:"routes"`
 }
 
 type PaymentMetadata struct {
-	DocumentID string             `json:"document_id"`
-	Authors    map[string]float64 `json:"authors"`
+	Source  string             `json:"source"`
+	Authors map[string]float64 `json:"authors"`
+}
+
+// URL returns the information in PaymentMetadata in URL-like fashion:
+func (pmd *PaymentMetadata) URL() string {
+	var url string
+	if pmd.Source != "" {
+		url += "source=" + pmd.Source
+	}
+
+	for acc, slice := range pmd.Authors {
+		if url != "" {
+			url += "&"
+		}
+		url += "user=" + acc + "," + fmt.Sprintf("%4.2f", slice)
+	}
+	return url
 }
 
 // AddInvoice godoc
@@ -197,90 +213,6 @@ func (controller *InvoiceController) AddInvoice(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, &responseBody)
-}
-
-// Invoice godoc
-// @Summary      Generate an invoice without credentials
-// @Description  Ask a user to generate an invoice
-// @Accept       json
-// @Produce      json
-// @Param        user_login path string true "User login or nickname"
-// @Param        amount path string true "amount in millisatoshis at the invoice"
-// @Tags         Invoice
-// @Success      200  {object}  InvoiceResponseBody
-// @Failure      400  {object}  responses.LnurlErrorResponse
-// @Failure      500  {object}  responses.LnurlErrorResponse
-// @Router       /v2/invoice/{user} [get]
-// @Security     OAuth2Password
-func (controller *InvoiceController) Invoice(c echo.Context) error {
-	// The user param could be userID (login) or a nickname (lnaddress)
-	user, err := controller.svc.FindUserByLoginOrNickname(c.Request().Context(), c.Param("user"))
-	if err != nil {
-		c.Logger().Errorf("Failed to find user by login or nickname: user %v error %v", c.Param("user"), err)
-		return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
-	}
-	var amt_msat int64 = -1
-	if c.QueryParams().Has("amount") {
-		amt_msat, err = strconv.ParseInt(c.QueryParam("amount"), 10, 64)
-		if err != nil {
-			c.Logger().Errorf("Could not convert %v to uint64. %v", c.QueryParam("amount"), err)
-			return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
-		}
-	}
-
-	if controller.svc.Config.MaxReceiveAmount > 0 && amt_msat/1000 > controller.svc.Config.MaxReceiveAmount {
-		c.Logger().Errorf("Max receive amount exceeded for user_id:%v (amount:%v)", user.ID, amt_msat/1000)
-		return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
-	}
-	paymentMeta := PaymentMetadata{Authors: map[string]float64{}}
-	if c.QueryParams().Has("account_id") {
-		for _, slice := range c.QueryParams()["account_id"] {
-			authorSlice := strings.Split(slice, ",")
-			if len(authorSlice) != 2 {
-				c.Logger().Debugf("account_id param must be in the format<acc_id>,<floatauthorship>, got %s", slice)
-				return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
-			}
-			authorship, err := strconv.ParseFloat(authorSlice[1], 64)
-			if err != nil {
-				c.Logger().Debugf("Could not parse authorship from account_id: %v", c.QueryParams()["account_id"])
-				return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
-			}
-			paymentMeta.Authors[authorSlice[0]] = authorship
-		}
-	}
-	if c.QueryParams().Has("document_id") {
-		paymentMeta.DocumentID = c.QueryParam("document_id")
-	}
-	records := []byte{}
-	if paymentMeta.DocumentID != "" {
-		records, err = json.Marshal(paymentMeta)
-		if err != nil {
-			c.Logger().Debugf("Could not parse to json: %v", paymentMeta)
-			return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
-		}
-	}
-	var descriptionhash_string string = ""
-	var memo string = ""
-	if c.QueryParams().Has("memo") {
-		memo = c.QueryParam("memo")
-	} else {
-		descriptionHash := lnurlDescriptionHash(user.Nickname, controller.svc.Config.LnurlDomain)
-		descriptionhash_hex := sha256.Sum256([]byte(descriptionHash))
-		descriptionhash_string = hex.EncodeToString(descriptionhash_hex[:])
-	}
-
-	c.Logger().Infof("Adding invoice: user_id:%v value:%v description_hash:%s memo:%s", user.ID, amt_msat/1000, descriptionhash_string, memo)
-	invoice, err := controller.svc.AddIncomingInvoice(c.Request().Context(), user.ID, amt_msat/1000, memo, descriptionhash_string, records...)
-	if err != nil {
-		c.Logger().Errorf("Error creating invoice: user_id:%v error: %v", user.ID, err)
-		sentry.CaptureException(err)
-		return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
-	}
-	responseBody := InvoiceResponseBody{}
-	responseBody.Payreq = invoice.PaymentRequest
-
-	return c.JSON(http.StatusOK, &responseBody)
-
 }
 
 // GetInvoice godoc

--- a/controllers_v2/invoice.ctrl.go
+++ b/controllers_v2/invoice.ctrl.go
@@ -97,7 +97,7 @@ func (controller *InvoiceController) GetOutgoingInvoices(c echo.Context) error {
 func (controller *InvoiceController) GetIncomingInvoices(c echo.Context) error {
 	userId := c.Get("UserID").(int64)
 
-	invoices, err := controller.svc.InvoicesFor(c.Request().Context(), userId, common.InvoiceTypeIncoming)
+	invoices, err := controller.svc.InvoicesIncomingAndInternalFor(c.Request().Context(), userId)
 	if err != nil {
 		return err
 	}
@@ -233,7 +233,7 @@ func (controller *InvoiceController) GetInvoice(c echo.Context) error {
 	invoice, err := controller.svc.FindInvoiceByPaymentHash(c.Request().Context(), userID, rHash)
 	// Probably we did not find the invoice
 	if err != nil {
-		c.Logger().Errorf("Invalid checkpayment request user_id:%v payment_hash:%s", userID, rHash)
+		c.Logger().Errorf("Invalid invoices request user_id:%v payment_hash:%s", userID, rHash)
 		return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
 	}
 	responseBody := Invoice{

--- a/controllers_v2/lnurl.ctrl.go
+++ b/controllers_v2/lnurl.ctrl.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -68,8 +69,15 @@ func (controller *InvoiceController) Lud6Invoice(c echo.Context) error {
 	cumulativeAuthorship := 0.0
 	var err error
 	users := []*models.User{}
-	captable := service.Captable{LeadingUserID: controller.svc.Config.HouseUserID, SecondaryUsers: map[int64]float64{}}
-
+	houseUser, err := controller.svc.FindUserByLogin(c.Request().Context(), controller.svc.Config.HouseUser)
+	if err != nil {
+		c.Logger().Errorf("Failed to find house user to collect and distribute payments on behalf of authors: %v", err)
+		return c.JSON(http.StatusInternalServerError, responses.GeneralServerError)
+	}
+	captable := service.Captable{LeadingUserID: houseUser.ID, SecondaryUsers: map[int64]float64{}}
+	c.Request().ParseForm()
+	params := c.Request().Form
+	fmt.Println(params)
 	for _, slice := range c.QueryParams()["user"] {
 		authorSlice := strings.Split(slice, ",")
 		user, err := controller.svc.FindUserByLoginOrNickname(c.Request().Context(), authorSlice[0])

--- a/controllers_v2/lnurl.ctrl.go
+++ b/controllers_v2/lnurl.ctrl.go
@@ -56,7 +56,7 @@ type LnurlpResponseBody struct {
 // @Success      200  {object}  Lud6InvoiceResponseBody
 // @Failure      400  {object}  responses.LnurlErrorResponse
 // @Failure      500  {object}  responses.LnurlErrorResponse
-// @Router       /v2/invoice/{user} [get]
+// @Router       /v2/invoice [get]
 // @Security     OAuth2Password
 func (controller *InvoiceController) Lud6Invoice(c echo.Context) error {
 	// The user param could be userID (login) or a nickname (lnaddress)

--- a/controllers_v2/lnurl.ctrl.go
+++ b/controllers_v2/lnurl.ctrl.go
@@ -67,7 +67,7 @@ func (controller *InvoiceController) Lud6Invoice(c echo.Context) error {
 	cumulativeAuthorship := 0.0
 	var err error
 	users := []*models.User{}
-	captable := service.Captable{LeadingUserID: controller.svc.Config.HouseUserID}
+	captable := service.Captable{LeadingUserID: controller.svc.Config.HouseUserID, SecondaryUsers: map[int64]float64{}}
 
 	for _, slice := range c.QueryParams()["user"] {
 		authorSlice := strings.Split(slice, ",")
@@ -146,7 +146,7 @@ func (controller *InvoiceController) Lud6Invoice(c echo.Context) error {
 	}
 	responseBody := Lud6InvoiceResponseBody{}
 	responseBody.Payreq = invoice.PaymentRequest
-
+	captable.Invoice = invoice
 	if err := controller.svc.SplitIncomingPayment(c.Request().Context(), captable); err != nil {
 		c.Logger().Errorf("Error splitting invoice: %v", err)
 		sentry.CaptureException(err)

--- a/controllers_v2/lnurl.ctrl.go
+++ b/controllers_v2/lnurl.ctrl.go
@@ -1,17 +1,26 @@
 package v2controllers
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 
+	"github.com/getAlby/lndhub.go/db/models"
 	"github.com/getAlby/lndhub.go/lib/responses"
 	"github.com/getAlby/lndhub.go/lib/service"
+	"github.com/getsentry/sentry-go"
 	"github.com/labstack/echo/v4"
 )
 
 const (
 	MIN_RECEIVABLE_MSATS = 1000
-	PREFIX_MSG           = "Sats for "
+	SERVICE_CUT_BPS      = 125 // 125 basis points
+	PREFIX_SINGLE_MSG    = "Sats for "
+	PREFIX_TWO_MSG       = "Sat to be split between "
+	PREFIX_MULTIPLE_MSG  = "Sat to be split among: "
 	LNURLP_COMMENT_SIZE  = 127
 	LNURLP_TAG           = "payRequest"
 )
@@ -32,6 +41,119 @@ type LnurlpResponseBody struct {
 	Metadata       string `json:"metadata"`
 	CommentAllowed uint   `json:"commentAllowed"`
 	Tag            string `json:"tag"`
+}
+
+// Lud6Invoice godoc
+// @Summary      Generate an invoice without credentials
+// @Description  Ask a user to generate an invoice
+// @Accept       json
+// @Produce      json
+// @Param        user_login path string true "User login or nickname"
+// @Param        amount path string true "amount in millisatoshis at the invoice"
+// @Tags         Lud6Invoice
+// @Success      200  {object}  Lud6InvoiceResponseBody
+// @Failure      400  {object}  responses.LnurlErrorResponse
+// @Failure      500  {object}  responses.LnurlErrorResponse
+// @Router       /v2/invoice/{user} [get]
+// @Security     OAuth2Password
+func (controller *InvoiceController) Lud6Invoice(c echo.Context) error {
+	// The user param could be userID (login) or a nickname (lnaddress)
+
+	if !c.QueryParams().Has("user") {
+		c.Logger().Errorf("user mandatory param in query URL")
+		return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
+	}
+	paymentMeta := PaymentMetadata{Authors: map[string]float64{}}
+	cumulativeAuthorship := 0.0
+	var err error
+	users := []*models.User{}
+	captable := service.Captable{LeadingUserID: controller.svc.Config.HouseUserID}
+
+	for _, slice := range c.QueryParams()["user"] {
+		authorSlice := strings.Split(slice, ",")
+		user, err := controller.svc.FindUserByLoginOrNickname(c.Request().Context(), authorSlice[0])
+		if err != nil {
+			c.Logger().Errorf("Failed to find user by login or nickname: user %v error %v", authorSlice[0], err)
+			return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
+		}
+		users = append(users, user)
+		if len(authorSlice) > 2 {
+			c.Logger().Debugf("user param must be in the format <id>,<floatauthorship> or <id>, got %s", slice)
+			return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
+		}
+		authorship := 1.0 - float64(SERVICE_CUT_BPS)/10000
+		if len(authorSlice) == 2 {
+			if authorship, err = strconv.ParseFloat(authorSlice[1], 64); err != nil {
+				c.Logger().Debugf("Could not parse authorship from user: %v", c.QueryParams()["user"])
+				return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
+			}
+		}
+
+		cumulativeAuthorship += authorship
+		paymentMeta.Authors[authorSlice[0]] = authorship
+		already, ok := captable.SecondaryUsers[user.ID]
+		if ok {
+			captable.SecondaryUsers[user.ID] = already + authorship
+		} else {
+			captable.SecondaryUsers[user.ID] = authorship
+		}
+	}
+	if cumulativeAuthorship > 1 {
+		c.Logger().Debugf("Slices added up more than 1: %v", cumulativeAuthorship)
+		return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
+	}
+
+	records, err := json.Marshal(paymentMeta)
+	if err != nil {
+		c.Logger().Debugf("Could not parse to json: %v", paymentMeta)
+		return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
+	}
+	var amt_msat int64 = -1
+	if c.QueryParams().Has("amount") {
+		amt_msat, err = strconv.ParseInt(c.QueryParam("amount"), 10, 64)
+		if err != nil {
+			c.Logger().Errorf("Could not convert %v to uint64. %v", c.QueryParam("amount"), err)
+			return c.JSON(http.StatusBadRequest, responses.BadArgumentsError)
+		}
+	}
+
+	if controller.svc.Config.MaxReceiveAmount > 0 && amt_msat/1000 > controller.svc.Config.MaxReceiveAmount {
+		c.Logger().Errorf("Max receive amount [%v] exceeded limit [%v]", amt_msat/1000, controller.svc.Config.MaxReceiveAmount)
+		return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
+	}
+
+	if c.QueryParams().Has("source") {
+		paymentMeta.Source = c.QueryParam("source")
+	}
+
+	var descriptionhash_string string = ""
+	var memo string = ""
+	if c.QueryParams().Has("memo") {
+		memo = c.QueryParam("memo")
+	} else {
+		descriptionHash := lnurlDescriptionHash(users, controller.svc.Config.LnurlDomain)
+		descriptionhash_hex := sha256.Sum256([]byte(descriptionHash))
+		descriptionhash_string = hex.EncodeToString(descriptionhash_hex[:])
+	}
+
+	c.Logger().Infof("Adding invoice: value:%v description_hash:%s memo:%s", amt_msat/1000, descriptionhash_string, memo)
+
+	invoice, err := controller.svc.AddIncomingInvoice(c.Request().Context(), captable.LeadingUserID, amt_msat/1000, memo, descriptionhash_string, records...)
+	if err != nil {
+		c.Logger().Errorf("Error creating invoice: %v", err)
+		sentry.CaptureException(err)
+		return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
+	}
+	responseBody := Lud6InvoiceResponseBody{}
+	responseBody.Payreq = invoice.PaymentRequest
+
+	if err := controller.svc.SplitIncomingPayment(c.Request().Context(), captable); err != nil {
+		c.Logger().Errorf("Error splitting invoice: %v", err)
+		sentry.CaptureException(err)
+		return c.JSON(http.StatusInternalServerError, responses.GeneralServerError)
+	}
+	return c.JSON(http.StatusOK, &responseBody)
+
 }
 
 // Lnurlp godoc
@@ -58,7 +180,7 @@ func (controller *LnurlController) Lnurlp(c echo.Context) error {
 	responseBody := &LnurlpResponseBody{}
 	responseBody.MinSendable = MIN_RECEIVABLE_MSATS
 	responseBody.MaxSendable = uint64(controller.svc.Config.MaxReceiveAmount * 1000)
-	responseBody.Callback = "https://" + controller.svc.Config.LnurlDomain + "/v2/invoice/" + c.Param("user")
+	responseBody.Callback = "https://" + controller.svc.Config.LnurlDomain + "/v2/invoice?user=" + c.Param("user")
 	if c.QueryParams().Has("amt") {
 		amt, err := strconv.ParseInt(c.QueryParam("amt"), 10, 64)
 		if err != nil {
@@ -71,15 +193,28 @@ func (controller *LnurlController) Lnurlp(c echo.Context) error {
 		}
 		responseBody.MinSendable = uint64(amt * 1000)
 		responseBody.MaxSendable = uint64(amt * 1000)
-		responseBody.Callback = responseBody.Callback + "?amount=" + strconv.FormatInt(amt*1000, 10)
+		responseBody.Callback = responseBody.Callback + "&amount=" + strconv.FormatInt(amt*1000, 10)
 	}
 
-	responseBody.Metadata = lnurlDescriptionHash(user.Nickname, controller.svc.Config.LnurlDomain)
+	responseBody.Metadata = lnurlDescriptionHash([]*models.User{user}, controller.svc.Config.LnurlDomain)
 	responseBody.CommentAllowed = LNURLP_COMMENT_SIZE
 	responseBody.Tag = LNURLP_TAG
 	return c.JSON(http.StatusOK, &responseBody)
 }
 
-func lnurlDescriptionHash(nickname, domain string) string {
-	return "[[\"text/identifier\", \"" + nickname + "@" + domain + "\"], [\"text/plain\", \"" + PREFIX_MSG + nickname + "\"]]"
+func lnurlDescriptionHash(users []*models.User, domain string) string {
+	switch len(users) {
+	case 0:
+		return ""
+	case 1:
+		return "[[\"text/email\", \"" + users[0].Nickname + "@" + domain + "\"], [\"text/plain\", \"" + PREFIX_SINGLE_MSG + users[0].Nickname + "\"]]"
+	case 2:
+		return "[[\"text/plain\", \"" + PREFIX_TWO_MSG + users[0].Nickname + " and " + users[1].Nickname + "\"]]"
+	default:
+		authors := []string{}
+		for _, a := range users {
+			authors = append(authors, a.Nickname)
+		}
+		return "[[\"text/plain\", \"" + PREFIX_MULTIPLE_MSG + strings.Join(authors[:], ", ") + "\"]]"
+	}
 }

--- a/controllers_v2/lnurl.ctrl.go
+++ b/controllers_v2/lnurl.ctrl.go
@@ -60,7 +60,9 @@ type LnurlpResponseBody struct {
 // @Security     OAuth2Password
 func (controller *InvoiceController) Lud6Invoice(c echo.Context) error {
 	// The user param could be userID (login) or a nickname (lnaddress)
-
+	c.Response().Header().Set("Access-Control-Allow-Origin", "*")
+	c.Response().Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
+	c.Response().Header().Set("Access-Control-Allow-Methods", "OPTIONS, GET")
 	if !c.QueryParams().Has("user") {
 		c.Logger().Errorf("user mandatory param in query URL")
 		return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)

--- a/controllers_v2/lnurl.ctrl.go
+++ b/controllers_v2/lnurl.ctrl.go
@@ -112,6 +112,10 @@ func (controller *InvoiceController) Lud6Invoice(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
 	}
 
+	if c.QueryParams().Has("source") {
+		paymentMeta.Source = c.QueryParam("source")
+	}
+
 	records, err := json.Marshal(paymentMeta)
 	if err != nil {
 		c.Logger().Debugf("Could not parse to json: %v", paymentMeta)
@@ -133,10 +137,6 @@ func (controller *InvoiceController) Lud6Invoice(c echo.Context) error {
 	if controller.svc.Config.MaxReceiveAmount > 0 && amt_msat/1000 > controller.svc.Config.MaxReceiveAmount {
 		c.Logger().Errorf("Provided amount [%v] exceeded max receive limit [%v]", amt_msat/1000, controller.svc.Config.MaxReceiveAmount)
 		return c.JSON(http.StatusBadRequest, responses.LnurlpBadArgumentsError)
-	}
-
-	if c.QueryParams().Has("source") {
-		paymentMeta.Source = c.QueryParam("source")
 	}
 
 	var descriptionhash_string string = ""

--- a/controllers_v2/payinvoice.ctrl.go
+++ b/controllers_v2/payinvoice.ctrl.go
@@ -66,7 +66,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 	paymentRequest = strings.ToLower(paymentRequest)
 	decodedPaymentRequest, err := controller.svc.DecodePaymentRequest(c.Request().Context(), paymentRequest)
 	if err != nil {
-		if strings.Contains(err.Error(),"invoice not for current active network") {
+		if strings.Contains(err.Error(), "invoice not for current active network") {
 			c.Logger().Errorf("Incorrect network user_id:%v error: %v", userID, err)
 			return c.JSON(http.StatusBadRequest, responses.IncorrectNetworkError)
 		}

--- a/controllers_v2/payinvoice.ctrl.go
+++ b/controllers_v2/payinvoice.ctrl.go
@@ -78,7 +78,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 		PayReq:  decodedPaymentRequest,
 		Keysend: false,
 	}
-	if (decodedPaymentRequest.Timestamp + decodedPaymentRequest.Expiry) < time.Now().Unix() {
+	if (decodedPaymentRequest.Timestamp + decodedPaymentRequest.Expiry/int64(time.Second)) < time.Now().Unix() {
 		c.Logger().Errorf("Payment request expired")
 		return c.JSON(http.StatusBadRequest, responses.InvoiceExpiredError)
 	}

--- a/controllers_v2/payinvoice.ctrl.go
+++ b/controllers_v2/payinvoice.ctrl.go
@@ -78,7 +78,7 @@ func (controller *PayInvoiceController) PayInvoice(c echo.Context) error {
 		PayReq:  decodedPaymentRequest,
 		Keysend: false,
 	}
-	if (decodedPaymentRequest.Timestamp + decodedPaymentRequest.Expiry/int64(time.Second)) < time.Now().Unix() {
+	if (decodedPaymentRequest.Timestamp + decodedPaymentRequest.Expiry) < time.Now().Unix() {
 		c.Logger().Errorf("Payment request expired")
 		return c.JSON(http.StatusBadRequest, responses.InvoiceExpiredError)
 	}

--- a/db/migrations/20230428103000_invoice_add_splitorigin.up.sql
+++ b/db/migrations/20230428103000_invoice_add_splitorigin.up.sql
@@ -1,0 +1,1 @@
+alter table invoices ADD COLUMN origin_user_id bigint;

--- a/db/models/invoice.go
+++ b/db/models/invoice.go
@@ -12,6 +12,7 @@ type Invoice struct {
 	ID                       int64             `json:"id" bun:",pk,autoincrement"`
 	Type                     string            `json:"type" validate:"required"`
 	UserID                   int64             `json:"user_id" validate:"required"`
+	OriginUserID             int64             `json:"origin_user_id" bun:",nullzero"`
 	User                     *User             `json:"-" bun:"rel:belongs-to,join:user_id=id"`
 	Amount                   int64             `json:"amount" validate:"gte=0"`
 	Fee                      int64             `json:"fee" bun:",nullzero"`

--- a/integration_tests/expected_requests_and_responses.go
+++ b/integration_tests/expected_requests_and_responses.go
@@ -57,11 +57,6 @@ type ExpectedBalanceResponse struct {
 	}
 }
 
-type Lud6InvoiceResponseBody struct {
-	Payreq string   `json:"pr"`
-	Routes []string `json:"routes"`
-}
-
 type ExpectedLnurlpResponseBody struct {
 	Callback       string `json:"callback"`
 	MaxSendable    uint64 `json:"maxSendable"`

--- a/integration_tests/expected_requests_and_responses.go
+++ b/integration_tests/expected_requests_and_responses.go
@@ -57,7 +57,7 @@ type ExpectedBalanceResponse struct {
 	}
 }
 
-type InvoiceResponseBody struct {
+type Lud6InvoiceResponseBody struct {
 	Payreq string   `json:"pr"`
 	Routes []string `json:"routes"`
 }

--- a/integration_tests/hodl_invoice_test.go
+++ b/integration_tests/hodl_invoice_test.go
@@ -210,13 +210,14 @@ func (suite *HodlInvoiceSuite) TestHodlInvoice() {
 	userBalance, err = suite.service.CurrentUserBalance(context.Background(), userId)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), int64(userFundingSats-externalSatRequested), userBalance)
-	// check payment is updated as succesful
+	// check payment is updated as successful
 	inv, err = suite.service.FindInvoiceByPaymentHash(context.Background(), userId, hex.EncodeToString(invoice.RHash))
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), common.InvoiceStateSettled, inv.State)
 	clearTable(suite.service, "invoices")
 	clearTable(suite.service, "transaction_entries")
 	clearTable(suite.service, "accounts")
+	clearTable(suite.service, "users")
 }
 
 func (suite *HodlInvoiceSuite) TearDownSuite() {

--- a/integration_tests/invoice_test.go
+++ b/integration_tests/invoice_test.go
@@ -57,7 +57,7 @@ func (suite *InvoiceTestSuite) TearDownTest() {
 	clearTable(suite.service, "invoices")
 }
 
-func (suite *InvoiceTestSuite) TestZeroAmtTestSuite() {
+func (suite *InvoiceTestSuite) TestZeroAmtInvoice() {
 	rec := httptest.NewRecorder()
 	var buf bytes.Buffer
 	assert.NoError(suite.T(), json.NewEncoder(&buf).Encode(&ExpectedV2AddInvoiceRequestBody{

--- a/integration_tests/lnd_mock.go
+++ b/integration_tests/lnd_mock.go
@@ -101,7 +101,7 @@ func (mlnd *MockLND) AddInvoice(ctx context.Context, req *lnrpc.Invoice, options
 		},
 		FallbackAddr: nil,
 	}
-	zpay32.Expiry(time.Duration(req.Expiry))(invoice)
+	zpay32.Expiry(time.Duration(req.Expiry * int64(time.Second)))(invoice)
 	copy(invoice.PaymentHash[:], pHash.Sum(nil))
 	copy(invoice.PaymentAddr[:], req.PaymentAddr)
 	if len(req.DescriptionHash) != 0 {

--- a/integration_tests/lnd_mock.go
+++ b/integration_tests/lnd_mock.go
@@ -101,7 +101,7 @@ func (mlnd *MockLND) AddInvoice(ctx context.Context, req *lnrpc.Invoice, options
 		},
 		FallbackAddr: nil,
 	}
-	zpay32.Expiry(time.Duration(req.Expiry * int64(time.Second)))(invoice)
+	zpay32.Expiry(time.Duration(req.Expiry))(invoice)
 	copy(invoice.PaymentHash[:], pHash.Sum(nil))
 	copy(invoice.PaymentAddr[:], req.PaymentAddr)
 	if len(req.DescriptionHash) != 0 {

--- a/integration_tests/lnurl_test.go
+++ b/integration_tests/lnurl_test.go
@@ -187,10 +187,8 @@ func (suite *LnurlTestSuite) TestSettleSplitPayment() {
 	suite.echo.ServeHTTP(rec3, req)
 	assert.Equal(suite.T(), http.StatusOK, rec3.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec3.Body).Decode(invoicesResponse))
-	for _, invoice := range invoicesResponse.Invoices {
-		assert.False(suite.T(), invoice.IsPaid)
-		assert.EqualValues(suite.T(), int(sliceAcc1*amountmsats/1000), invoice.Amount)
-	}
+	assert.False(suite.T(), invoicesResponse.Invoices[0].IsPaid)
+	assert.EqualValues(suite.T(), int(sliceAcc1*amountmsats/1000), invoicesResponse.Invoices[0].Amount)
 	balance = suite.getBalance(suite.userToken[1])
 	assert.EqualValues(suite.T(), 0, balance)
 
@@ -201,10 +199,8 @@ func (suite *LnurlTestSuite) TestSettleSplitPayment() {
 	suite.echo.ServeHTTP(rec4, req)
 	assert.Equal(suite.T(), http.StatusOK, rec4.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec4.Body).Decode(invoicesResponse))
-	for _, invoice := range invoicesResponse.Invoices {
-		assert.False(suite.T(), invoice.IsPaid)
-		assert.EqualValues(suite.T(), int(sliceAcc2*amountmsats/1000), invoice.Amount)
-	}
+	assert.False(suite.T(), invoicesResponse.Invoices[0].IsPaid)
+	assert.EqualValues(suite.T(), int(sliceAcc2*amountmsats/1000), invoicesResponse.Invoices[0].Amount)
 	balance = suite.getBalance(suite.userToken[2])
 	assert.EqualValues(suite.T(), 0, balance)
 
@@ -265,7 +261,7 @@ func (suite *LnurlTestSuite) TestSettleSplitPayment() {
 }
 func (suite *LnurlTestSuite) TestGetLnurlInvoiceZeroAmt() {
 	// call the lnurl endpoint
-	req := httptest.NewRequest(http.MethodGet, "/v2/lnurlp/"+suite.userLogin[0].Login, nil)
+	req := httptest.NewRequest(http.MethodGet, "/v2/lnurlp/"+suite.userLogin[1].Login, nil)
 	rec := httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec, req)
 	lnurlResponse := &ExpectedLnurlpResponseBody{}
@@ -299,7 +295,7 @@ func (suite *LnurlTestSuite) TestGetLnurlInvoiceCustomAmt() {
 	// call the lnurl endpoint
 	const payreq_type = "payRequest"
 	const amt_sats = int64(1245)
-	req := httptest.NewRequest(http.MethodGet, "/v2/lnurlp/"+suite.userLogin[0].Login+"?amt="+strconv.FormatInt(amt_sats, 10), nil)
+	req := httptest.NewRequest(http.MethodGet, "/v2/lnurlp/"+suite.userLogin[1].Login+"?amt="+strconv.FormatInt(amt_sats, 10), nil)
 	rec := httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec, req)
 	lnurlResponse := &ExpectedLnurlpResponseBody{}

--- a/integration_tests/lnurl_test.go
+++ b/integration_tests/lnurl_test.go
@@ -198,25 +198,23 @@ func (suite *LnurlTestSuite) TestInternalSplitPayment() {
 	assert.EqualValues(suite.T(), amountmsats/1000, invoiceResponse.Amount)
 	assert.False(suite.T(), invoiceResponse.IsPaid)
 
-	// Check split invoice exists and is not paid
+	// Check split invoice does not exist yet
 	req = httptest.NewRequest(http.MethodGet, "/v2/invoices/incoming", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.userToken[1]))
 	rec3 := httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec3, req)
 	assert.Equal(suite.T(), http.StatusOK, rec3.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec3.Body).Decode(invoicesResponse))
-	assert.False(suite.T(), invoicesResponse.Invoices[0].IsPaid)
-	assert.EqualValues(suite.T(), int(sliceAcc1*amountmsats/1000), invoicesResponse.Invoices[0].Amount)
+	assert.Len(suite.T(), invoicesResponse.Invoices, 0)
 
-	// Check the other split invoice exists and is not paid
+	// Check the other split invoice does not exist yet
 	req = httptest.NewRequest(http.MethodGet, "/v2/invoices/incoming", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.userToken[2]))
 	rec4 := httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec4, req)
 	assert.Equal(suite.T(), http.StatusOK, rec4.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec4.Body).Decode(invoicesResponse))
-	assert.False(suite.T(), invoicesResponse.Invoices[0].IsPaid)
-	assert.EqualValues(suite.T(), int(sliceAcc2*amountmsats/1000), invoicesResponse.Invoices[0].Amount)
+	assert.Len(suite.T(), invoicesResponse.Invoices, 0)
 
 	//fund payer's account
 	fundInvoiceResponse := suite.createAddInvoiceReq(amountmsats*1.1, "funding account", suite.userToken[3])

--- a/integration_tests/lnurl_test.go
+++ b/integration_tests/lnurl_test.go
@@ -3,8 +3,6 @@ package integration_tests
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -89,24 +87,24 @@ func (suite *LnurlTestSuite) TestLud6InvoiceWithMetadata() {
 	rec := httptest.NewRecorder()
 	const fakeAcc = "bafkreibaejvf3wyblh3s4yhbrwtxto7wpcac7zkkx36cswjzjez2cbmzvu"
 	memo := "Invoicememo😀"
+	var amountmsats = 12000
 	//failed user
 	req := httptest.NewRequest(http.MethodGet, "/v2/invoice?user="+fakeAcc, nil)
 	suite.echo.ServeHTTP(rec, req)
 	assert.Equal(suite.T(), http.StatusBadRequest, rec.Code)
 	//single user + memo
 	rec2 := httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodGet, "/v2/invoice?user="+suite.userLogin[1].Login+"&memo="+memo, nil)
+	req = httptest.NewRequest(http.MethodGet, "/v2/invoice?user="+suite.userLogin[1].Login+"&memo="+memo+"&amount="+strconv.Itoa(amountmsats), nil)
 	suite.echo.ServeHTTP(rec2, req)
 	assert.Equal(suite.T(), http.StatusOK, rec2.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec2.Body).Decode(invoiceResponse))
 	decodedPayreq, err := suite.mlnd.DecodeBolt11(context.Background(), invoiceResponse.Payreq)
 	assert.NoError(suite.T(), err)
-	assert.EqualValues(suite.T(), 0, decodedPayreq.NumMsat)
+	assert.EqualValues(suite.T(), amountmsats, decodedPayreq.NumMsat)
 	assert.EqualValues(suite.T(), memo, decodedPayreq.Description)
 	//2 users + amount
 	const sliceAcc1 = 0.45
 	const sliceAcc2 = 0.53
-	var amountmsats = 12000
 	metadata := &v2controllers.PaymentMetadata{
 		Source:  "",
 		Authors: map[string]float64{suite.userLogin[1].Login: sliceAcc1, suite.userLogin[2].Login: sliceAcc2},
@@ -129,7 +127,7 @@ func (suite *LnurlTestSuite) TestLud6InvoiceWithMetadata() {
 	//3 users + source
 	metadata.Authors[suite.userLogin[3].Login] = 0.02
 	metadata.Source = fakeAcc
-	req = httptest.NewRequest(http.MethodGet, "/v2/invoice?"+metadata.URL(), nil)
+	req = httptest.NewRequest(http.MethodGet, "/v2/invoice?"+metadata.URL()+"&amount="+strconv.Itoa(amountmsats), nil)
 	rec5 := httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec5, req)
 	assert.Equal(suite.T(), http.StatusOK, rec5.Code)
@@ -151,7 +149,7 @@ func (suite *LnurlTestSuite) TestLud6InvoiceWithMetadata() {
 	}
 	url := strings.Replace(metadata.URL(), suite.userLogin[3].Login, suite.userLogin[4].Login, -1)
 	url = strings.Replace(url, suite.userLogin[6].Login, suite.userLogin[5].Login, -1)
-	req = httptest.NewRequest(http.MethodGet, "/v2/invoice?"+url, nil)
+	req = httptest.NewRequest(http.MethodGet, "/v2/invoice?"+url+"&amount="+strconv.Itoa(amountmsats), nil)
 	rec6 := httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec6, req)
 	assert.Equal(suite.T(), http.StatusOK, rec6.Code)
@@ -346,36 +344,11 @@ func (suite *LnurlTestSuite) TestGetLnurlInvoiceZeroAmt() {
 	req := httptest.NewRequest(http.MethodGet, "/v2/lnurlp/"+suite.userLogin[1].Login, nil)
 	rec := httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec, req)
-	lnurlResponse := &ExpectedLnurlpResponseBody{}
-	assert.Equal(suite.T(), http.StatusOK, rec.Code)
-	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(lnurlResponse))
-	assert.EqualValues(suite.T(), lnurlResponse.Tag, v2controllers.LNURLP_TAG)
-	assert.EqualValues(suite.T(), lnurlResponse.CommentAllowed, v2controllers.LNURLP_COMMENT_SIZE)
-	assert.EqualValues(suite.T(), lnurlResponse.MinSendable, 1000)
-	assert.EqualValues(suite.T(), lnurlResponse.MaxSendable, suite.service.Config.MaxReceiveAmount*1000)
-	urlStart := strings.Index(lnurlResponse.Callback, "/v2/invoice")
-	assert.Greater(suite.T(), urlStart, 0)
-
-	// call callback
-	req = httptest.NewRequest(http.MethodGet, lnurlResponse.Callback[urlStart:], nil)
-	rec2 := httptest.NewRecorder()
-	suite.echo.ServeHTTP(rec2, req)
-	invoiceResponse := &v2controllers.Lud6InvoiceResponseBody{}
-	assert.Equal(suite.T(), http.StatusOK, rec2.Code)
-	assert.NoError(suite.T(), json.NewDecoder(rec2.Body).Decode(invoiceResponse))
-	assert.Equal(suite.T(), 0, len(invoiceResponse.Routes))
-	decodedPayreq, err := suite.mlnd.DecodeBolt11(context.Background(), invoiceResponse.Payreq)
-	assert.NoError(suite.T(), err)
-	assert.EqualValues(suite.T(), 0, decodedPayreq.NumMsat)
-	assert.NoError(suite.T(), err)
-	descriptionHash := sha256.Sum256([]byte(lnurlResponse.Metadata))
-	expectedPH := hex.EncodeToString(descriptionHash[:])
-	assert.EqualValues(suite.T(), expectedPH, decodedPayreq.DescriptionHash)
+	assert.Equal(suite.T(), http.StatusBadRequest, rec.Code)
 }
 
 func (suite *LnurlTestSuite) TestGetLnurlInvoiceCustomAmt() {
 	// call the lnurl endpoint
-	const payreq_type = "payRequest"
 	const amt_sats = int64(1245)
 	req := httptest.NewRequest(http.MethodGet, "/v2/lnurlp/"+suite.userLogin[1].Login+"?amt="+strconv.FormatInt(amt_sats, 10), nil)
 	rec := httptest.NewRecorder()
@@ -383,7 +356,8 @@ func (suite *LnurlTestSuite) TestGetLnurlInvoiceCustomAmt() {
 	lnurlResponse := &ExpectedLnurlpResponseBody{}
 	assert.Equal(suite.T(), http.StatusOK, rec.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec.Body).Decode(lnurlResponse))
-	assert.Equal(suite.T(), lnurlResponse.Tag, payreq_type)
+	assert.EqualValues(suite.T(), lnurlResponse.Tag, v2controllers.LNURLP_TAG)
+	assert.EqualValues(suite.T(), lnurlResponse.CommentAllowed, v2controllers.LNURLP_COMMENT_SIZE)
 	assert.EqualValues(suite.T(), lnurlResponse.MinSendable, amt_sats*1000)
 	assert.EqualValues(suite.T(), lnurlResponse.MaxSendable, amt_sats*1000)
 	urlStart := strings.Index(lnurlResponse.Callback, "/v2/invoice")

--- a/integration_tests/lnurl_test.go
+++ b/integration_tests/lnurl_test.go
@@ -86,7 +86,7 @@ func (suite *LnurlTestSuite) TestLud6InvoiceWithMetadata() {
 	//2 users + amount
 	const sliceAcc1 = 0.45
 	const sliceAcc2 = 0.53
-	const amountmsats = 12003
+	const amountmsats = 12000
 	metadata := &v2controllers.PaymentMetadata{
 		Source:  "",
 		Authors: map[string]float64{suite.userLogin[1].Login: sliceAcc1, suite.userLogin[2].Login: sliceAcc2},
@@ -95,6 +95,7 @@ func (suite *LnurlTestSuite) TestLud6InvoiceWithMetadata() {
 	rec3 := httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec3, req)
 	assert.Equal(suite.T(), http.StatusOK, rec3.Code)
+	assert.NoError(suite.T(), json.NewDecoder(rec3.Body).Decode(invoiceResponse))
 	decodedPayreq, err = suite.mlnd.DecodeBolt11(context.Background(), invoiceResponse.Payreq)
 	assert.NoError(suite.T(), err)
 	assert.EqualValues(suite.T(), amountmsats, decodedPayreq.NumMsat)
@@ -111,12 +112,12 @@ func (suite *LnurlTestSuite) TestLud6InvoiceWithMetadata() {
 	req = httptest.NewRequest(http.MethodGet, "/v2/invoice?"+metadata.URL(), nil)
 	rec5 := httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec5, req)
-	assert.Equal(suite.T(), http.StatusBadRequest, rec5.Code)
-	assert.NoError(suite.T(), json.NewDecoder(rec2.Body).Decode(invoiceResponse))
+	assert.Equal(suite.T(), http.StatusOK, rec5.Code)
+	assert.NoError(suite.T(), json.NewDecoder(rec5.Body).Decode(invoiceResponse))
 	assert.Equal(suite.T(), 0, len(invoiceResponse.Routes))
 	decodedPayreq, err = suite.mlnd.DecodeBolt11(context.Background(), invoiceResponse.Payreq)
 	assert.NoError(suite.T(), err)
-	assert.EqualValues(suite.T(), "", decodedPayreq.DescriptionHash)
+	assert.EqualValues(suite.T(), "87e04946ff05ec28174aeb6f0e19f8295304a70f45f19bb3d915dc9aa6976587", decodedPayreq.DescriptionHash)
 
 }
 

--- a/integration_tests/lnurl_test.go
+++ b/integration_tests/lnurl_test.go
@@ -247,8 +247,8 @@ func (suite *LnurlTestSuite) TestSettleSplitPayment() {
 	assert.Equal(suite.T(), http.StatusOK, rec7.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec7.Body).Decode(invoicesResponse))
 	assert.True(suite.T(), invoicesResponse.Invoices[0].IsPaid)
-	assert.EqualValues(suite.T(), int(1*amountmsats/1000), invoicesResponse.Invoices[0].Amount)
-	balance = suite.getBalance(suite.userToken[0])
+	assert.EqualValues(suite.T(), int(sliceAcc1*amountmsats/1000), invoicesResponse.Invoices[0].Amount)
+	balance = suite.getBalance(suite.userToken[1])
 	assert.EqualValues(suite.T(), sliceAcc1*amountmsats/1000, balance)
 
 	// Check the other split invoice exists and is paid
@@ -258,9 +258,9 @@ func (suite *LnurlTestSuite) TestSettleSplitPayment() {
 	suite.echo.ServeHTTP(rec8, req)
 	assert.Equal(suite.T(), http.StatusOK, rec8.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec8.Body).Decode(invoicesResponse))
-	assert.False(suite.T(), invoicesResponse.Invoices[0].IsPaid)
+	assert.True(suite.T(), invoicesResponse.Invoices[0].IsPaid)
 	assert.EqualValues(suite.T(), int(sliceAcc2*amountmsats/1000), invoicesResponse.Invoices[0].Amount)
-	balance = suite.getBalance(suite.userToken[0])
+	balance = suite.getBalance(suite.userToken[2])
 	assert.EqualValues(suite.T(), sliceAcc2*amountmsats/1000, balance)
 }
 func (suite *LnurlTestSuite) TestGetLnurlInvoiceZeroAmt() {

--- a/integration_tests/lnurl_test.go
+++ b/integration_tests/lnurl_test.go
@@ -75,25 +75,13 @@ func (suite *LnurlTestSuite) SetupSuite() {
 }
 
 func (suite *LnurlTestSuite) TearDownTest() {
-	err := clearTable(suite.service, "invoices")
-	if err != nil {
-		fmt.Printf("Tear down test error %v\n", err.Error())
-		return
-	}
-	err = clearTable(suite.service, "transaction_entries")
-	if err != nil {
-		fmt.Printf("Tear down test error %v\n", err.Error())
-		return
-	}
+	clearTable(suite.service, "invoices")
+	clearTable(suite.service, "transaction_entries")
 	fmt.Println("Tear down test success")
 }
 func (suite *LnurlTestSuite) TearDownSuite() {
 	suite.invoiceUpdateSubCancelFn()
-	err := clearTable(suite.service, "users")
-	if err != nil {
-		fmt.Printf("Tear down suite error %v\n", err.Error())
-		return
-	}
+	clearTable(suite.service, "users")
 }
 
 func (suite *LnurlTestSuite) TestLud6InvoiceWithMetadata() {

--- a/integration_tests/lnurl_test.go
+++ b/integration_tests/lnurl_test.go
@@ -89,7 +89,6 @@ func (suite *LnurlTestSuite) TearDownSuite() {
 	fmt.Println("Tear down suite success")
 }
 
-// TODO: launch a goroutine that listen for paid invoices and then settle the splits associated with them (call sendInternalPayment)
 func (suite *LnurlTestSuite) TestLud6InvoiceWithMetadata() {
 	invoiceResponse := &v2controllers.Lud6InvoiceResponseBody{}
 	rec := httptest.NewRecorder()
@@ -205,8 +204,8 @@ func (suite *LnurlTestSuite) TestInternalSplitPayment() {
 	assert.NoError(suite.T(), json.NewDecoder(rec2.Body).Decode(invoiceResponse))
 	assert.EqualValues(suite.T(), amountmsats/1000, invoiceResponse.Amount)
 	assert.False(suite.T(), invoiceResponse.IsPaid)
-	balance := suite.getBalance(suite.houseToken)
-	assert.EqualValues(suite.T(), 0, balance)
+	//balance := suite.getBalance(suite.houseToken)
+	//assert.EqualValues(suite.T(), 0, balance)
 
 	// Check split invoice exists and is not paid
 	req = httptest.NewRequest(http.MethodGet, "/v2/invoices/incoming", nil)
@@ -217,7 +216,7 @@ func (suite *LnurlTestSuite) TestInternalSplitPayment() {
 	assert.NoError(suite.T(), json.NewDecoder(rec3.Body).Decode(invoicesResponse))
 	assert.False(suite.T(), invoicesResponse.Invoices[0].IsPaid)
 	assert.EqualValues(suite.T(), int(sliceAcc1*amountmsats/1000), invoicesResponse.Invoices[0].Amount)
-	balance = suite.getBalance(suite.userToken[1])
+	balance := suite.getBalance(suite.userToken[1])
 	assert.EqualValues(suite.T(), 0, balance)
 
 	// Check the other split invoice exists and is not paid
@@ -260,8 +259,8 @@ func (suite *LnurlTestSuite) TestInternalSplitPayment() {
 	assert.NoError(suite.T(), json.NewDecoder(rec6.Body).Decode(invoicesResponse))
 	assert.EqualValues(suite.T(), amountmsats/1000, invoicesResponse.Invoices[0].Amount)
 	assert.True(suite.T(), invoicesResponse.Invoices[0].IsPaid)
-	balance = suite.getBalance(suite.houseToken)
-	assert.EqualValues(suite.T(), (1-sliceAcc1-sliceAcc2)*amountmsats/1000, balance)
+	//balance = suite.getBalance(suite.houseToken)
+	//assert.EqualValues(suite.T(), (1-sliceAcc1-sliceAcc2)*amountmsats/1000, balance)
 
 	// Check split invoice exists and is paid
 	req = httptest.NewRequest(http.MethodGet, "/v2/invoices/incoming", nil)
@@ -316,14 +315,14 @@ func (suite *LnurlTestSuite) TestExternalSplitPayment() {
 
 	// Check Lead invoice invoice exists and is paid
 	req = httptest.NewRequest(http.MethodGet, "/v2/invoices/incoming", nil)
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.userToken[0]))
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", suite.houseToken))
 	rec6 := httptest.NewRecorder()
 	suite.echo.ServeHTTP(rec6, req)
 	assert.Equal(suite.T(), http.StatusOK, rec6.Code)
 	assert.NoError(suite.T(), json.NewDecoder(rec6.Body).Decode(invoicesResponse))
 	assert.EqualValues(suite.T(), amountmsats/1000, invoicesResponse.Invoices[0].Amount)
 	assert.True(suite.T(), invoicesResponse.Invoices[0].IsPaid)
-	balance := suite.getBalance(suite.userToken[0])
+	balance := suite.getBalance(suite.houseToken)
 	assert.EqualValues(suite.T(), (1-sliceAcc1-sliceAcc2)*amountmsats/1000, balance)
 
 	// Check split invoice exists and is paid

--- a/integration_tests/rabbitmq_test.go
+++ b/integration_tests/rabbitmq_test.go
@@ -35,7 +35,6 @@ type RabbitMQTestSuite struct {
 }
 
 func (suite *RabbitMQTestSuite) SetupSuite() {
-	suite.T().Skip()
 	mlnd := newDefaultMockLND()
 	//needs different pubkey
 	//to allow for "external" payments

--- a/integration_tests/rabbitmq_test.go
+++ b/integration_tests/rabbitmq_test.go
@@ -35,6 +35,7 @@ type RabbitMQTestSuite struct {
 }
 
 func (suite *RabbitMQTestSuite) SetupSuite() {
+	suite.T().Skip()
 	mlnd := newDefaultMockLND()
 	//needs different pubkey
 	//to allow for "external" payments
@@ -246,6 +247,7 @@ func (suite *RabbitMQTestSuite) TearDownSuite() {
 
 	err = ch.ExchangeDelete(suite.svc.Config.RabbitMQLndhubInvoiceExchange, true, false)
 	assert.NoError(suite.T(), err)
+	clearTable(suite.svc, "invoices")
 }
 
 func TestRabbitMQTestSuite(t *testing.T) {

--- a/integration_tests/util.go
+++ b/integration_tests/util.go
@@ -45,6 +45,7 @@ func LndHubTestServiceInit(lndClientMock lnd.LightningClientWrapper) (svc *servi
 		MaxReceiveAmount:        1000000,
 		MaxSendAmount:           100000,
 		LnurlDomain:             "testnet.example.com",
+		HouseUserID:             1,
 	}
 
 	rabbitmqUri, ok := os.LookupEnv("RABBITMQ_URI")
@@ -124,6 +125,9 @@ func createUsers(svc *service.LndhubService, usersToCreate int) (logins []Expect
 			return nil, nil, err
 		}
 		var login ExpectedCreateUserResponseBody
+		if i == 0 {
+			svc.Config.HouseUserID = user.ID
+		}
 		login.Login = user.Login
 		login.Password = user.Password
 		login.Nickname = user.Nickname

--- a/integration_tests/util.go
+++ b/integration_tests/util.go
@@ -28,6 +28,7 @@ import (
 const (
 	mockLNDAddress     = "mock.lnd.local"
 	mockLNDMacaroonHex = "omnomnom"
+	mockHousePassword  = "49ol65QxsuIvnTJaRWht"
 )
 
 func LndHubTestServiceInit(lndClientMock lnd.LightningClientWrapper) (svc *service.LndhubService, err error) {
@@ -45,7 +46,7 @@ func LndHubTestServiceInit(lndClientMock lnd.LightningClientWrapper) (svc *servi
 		MaxReceiveAmount:        1000000,
 		MaxSendAmount:           100000,
 		LnurlDomain:             "testnet.example.com",
-		HouseUserID:             1,
+		HouseUser:               "6CXQAGHM52tYlpysOSry",
 	}
 
 	rabbitmqUri, ok := os.LookupEnv("RABBITMQ_URI")
@@ -95,6 +96,10 @@ func LndHubTestServiceInit(lndClientMock lnd.LightningClientWrapper) (svc *servi
 	svc.IdentityPubkey = getInfo.IdentityPubkey
 
 	svc.InvoicePubSub = service.NewPubsub()
+	// create user collecting remainder of splitting payments
+	if _, err := svc.CreateUser(context.Background(), svc.Config.HouseUser, mockHousePassword, ""); err != nil {
+		logger.Fatalf("Error Creating House User: %v", err)
+	}
 	return svc, nil
 }
 
@@ -125,9 +130,6 @@ func createUsers(svc *service.LndhubService, usersToCreate int) (logins []Expect
 			return nil, nil, err
 		}
 		var login ExpectedCreateUserResponseBody
-		if i == 0 {
-			svc.Config.HouseUserID = user.ID
-		}
 		login.Login = user.Login
 		login.Password = user.Password
 		login.Nickname = user.Nickname

--- a/legacy_endpoints.go
+++ b/legacy_endpoints.go
@@ -9,11 +9,11 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
-func RegisterLegacyEndpoints(svc *service.LndhubService, e *echo.Echo, tokenMW, strictRateLimitPerMinMW, strictRateLimitPerSecMW, rateLimitPerMinMW, rateLimitPerSecMW echo.MiddlewareFunc) {
+func RegisterLegacyEndpoints(svc *service.LndhubService, e *echo.Echo, tokenMW, strictRateLimitPerMinMW, strictRateLimitPerSecMW, rateLimitPerMinMW, rateLimitPerSecMW echo.MiddlewareFunc, adminMw echo.MiddlewareFunc) {
 	// Public endpoints for account creation and authentication
 	e.POST("/auth", controllers.NewAuthController(svc).Auth)
 	if svc.Config.AllowAccountCreation {
-		e.POST("/create", controllers.NewCreateUserController(svc).CreateUser, strictRateLimitPerMinMW, strictRateLimitPerSecMW)
+		e.POST("/create", controllers.NewCreateUserController(svc).CreateUser, strictRateLimitPerMinMW, strictRateLimitPerSecMW, adminMw)
 	}
 	e.POST("/invoice/:user_login", controllers.NewInvoiceController(svc).Invoice, rateLimitPerMinMW, rateLimitPerSecMW)
 

--- a/lib/responses/errors.go
+++ b/lib/responses/errors.go
@@ -3,6 +3,8 @@ package responses
 import (
 	"net/http"
 
+	"errors"
+
 	"github.com/getsentry/sentry-go"
 	sentryecho "github.com/getsentry/sentry-go/echo"
 	"github.com/labstack/echo/v4"
@@ -95,6 +97,8 @@ var NotEnoughBalanceError = ErrorResponse{
 	Message:        "not enough balance. Make sure you have at least 1% reserved for potential fees",
 	HttpStatusCode: 400,
 }
+
+var LeadAuthorIncludedError = errors.New("Leading user cannot be in the list of secondary users")
 
 func HTTPErrorHandler(err error, c echo.Context) {
 	if c.Response().Committed {

--- a/lib/service/config.go
+++ b/lib/service/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	RabbitMQUri                      string  `envconfig:"RABBITMQ_URI"`
 	RabbitMQLndhubInvoiceExchange    string  `envconfig:"RABBITMQ_INVOICE_EXCHANGE" default:"lndhub_invoice"`
 	LnurlDomain                      string  `envconfig:"LNURL_DOMAIN" default:"ln.example.com"`
+	HouseUserID                      int64   `envconfig:"LNURL_HOUSE_USER_ID" default:"0"`
 	RabbitMQLndInvoiceExchange       string  `envconfig:"RABBITMQ_LND_INVOICE_EXCHANGE" default:"lnd_invoice"`
 	RabbitMQInvoiceConsumerQueueName string  `envconfig:"RABBITMQ_INVOICE_CONSUMER_QUEUE_NAME" default:"lnd_invoice_consumer"`
 	SubscriptionConsumerType         string  `envconfig:"SUBSCRIPTION_CONSUMER_TYPE" default:"grpc"`

--- a/lib/service/config.go
+++ b/lib/service/config.go
@@ -45,7 +45,7 @@ type Config struct {
 	RabbitMQUri                      string  `envconfig:"RABBITMQ_URI"`
 	RabbitMQLndhubInvoiceExchange    string  `envconfig:"RABBITMQ_INVOICE_EXCHANGE" default:"lndhub_invoice"`
 	LnurlDomain                      string  `envconfig:"LNURL_DOMAIN" default:"ln.example.com"`
-	HouseUserID                      int64   `envconfig:"LNURL_HOUSE_USER_ID" default:"1"`
+	HouseUser                        string  `envconfig:"LNURL_HOUSE_NICKNAME" default:"6CXQAGHM52tYlpysOSry"`
 	RabbitMQLndInvoiceExchange       string  `envconfig:"RABBITMQ_LND_INVOICE_EXCHANGE" default:"lnd_invoice"`
 	RabbitMQInvoiceConsumerQueueName string  `envconfig:"RABBITMQ_INVOICE_CONSUMER_QUEUE_NAME" default:"lnd_invoice_consumer"`
 	SubscriptionConsumerType         string  `envconfig:"SUBSCRIPTION_CONSUMER_TYPE" default:"grpc"`

--- a/lib/service/config.go
+++ b/lib/service/config.go
@@ -45,7 +45,7 @@ type Config struct {
 	RabbitMQUri                      string  `envconfig:"RABBITMQ_URI"`
 	RabbitMQLndhubInvoiceExchange    string  `envconfig:"RABBITMQ_INVOICE_EXCHANGE" default:"lndhub_invoice"`
 	LnurlDomain                      string  `envconfig:"LNURL_DOMAIN" default:"ln.example.com"`
-	HouseUserID                      int64   `envconfig:"LNURL_HOUSE_USER_ID" default:"0"`
+	HouseUserID                      int64   `envconfig:"LNURL_HOUSE_USER_ID" default:"1"`
 	RabbitMQLndInvoiceExchange       string  `envconfig:"RABBITMQ_LND_INVOICE_EXCHANGE" default:"lnd_invoice"`
 	RabbitMQInvoiceConsumerQueueName string  `envconfig:"RABBITMQ_INVOICE_CONSUMER_QUEUE_NAME" default:"lnd_invoice_consumer"`
 	SubscriptionConsumerType         string  `envconfig:"SUBSCRIPTION_CONSUMER_TYPE" default:"grpc"`

--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -311,7 +311,7 @@ func (svc *LndhubService) HandleSuccessfulPayment(ctx context.Context, invoice *
 	_, err := svc.DB.NewUpdate().Model(invoice).WherePK().Exec(ctx)
 	if err != nil {
 		sentry.CaptureException(err)
-		svc.Logger.Errorf("Could not update sucessful payment invoice user_id:%v invoice_id:%v, error %s", invoice.UserID, invoice.ID, err.Error())
+		svc.Logger.Errorf("Could not update successful payment invoice user_id:%v invoice_id:%v, error %s", invoice.UserID, invoice.ID, err.Error())
 	}
 
 	// Get the user's fee account for the transaction entry, current account is already there in parent entry
@@ -389,7 +389,7 @@ func (svc *LndhubService) SplitIncomingPayment(ctx context.Context, captable Cap
 			return fmt.Errorf("%s", errMsg)
 		}
 		internalInvoice := models.Invoice{
-			Type:                     common.InvoiceStateError,
+			Type:                     captable.Invoice.Type,
 			UserID:                   user,
 			Amount:                   int64(float64(captable.Invoice.Amount) * slice),
 			Memo:                     captable.Invoice.Memo,

--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -389,17 +389,14 @@ func (svc *LndhubService) SplitIncomingPayment(ctx context.Context, captable Cap
 			return responses.LeadAuthorIncludedError
 		}
 		internalInvoice := models.Invoice{
-			Type:                     captable.Invoice.Type,
+			Type:                     common.InvoiceTypeSubinvoice,
 			UserID:                   user,
 			Amount:                   int64(float64(captable.Invoice.Amount) * slice),
 			Memo:                     captable.Invoice.Memo,
-			DescriptionHash:          captable.Invoice.DescriptionHash,
-			State:                    common.InvoiceStateInitialized,
+			State:                    common.InvoiceStateOpen,
 			ExpiresAt:                captable.Invoice.ExpiresAt,
 			DestinationCustomRecords: captable.Invoice.DestinationCustomRecords,
 			PaymentRequest:           captable.Invoice.PaymentRequest,
-			RHash:                    captable.Invoice.RHash,
-			Preimage:                 captable.Invoice.Preimage,
 			AddIndex:                 captable.Invoice.AddIndex,
 			DestinationPubkeyHex:     captable.Invoice.DestinationPubkeyHex,
 		}
@@ -407,7 +404,6 @@ func (svc *LndhubService) SplitIncomingPayment(ctx context.Context, captable Cap
 		if _, err := svc.DB.NewInsert().Model(&internalInvoice).Exec(ctx); err != nil {
 			return err
 		}
-		internalInvoice.State = common.InvoiceStateOpen
 	}
 	return nil
 }

--- a/lib/service/invoices.go
+++ b/lib/service/invoices.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/getAlby/lndhub.go/common"
 	"github.com/getAlby/lndhub.go/db/models"
+	"github.com/getAlby/lndhub.go/lib/responses"
 	"github.com/getAlby/lndhub.go/lnd"
 	"github.com/getsentry/sentry-go"
 	"github.com/labstack/gommon/random"
@@ -384,9 +385,8 @@ func (svc *LndhubService) AddOutgoingInvoice(ctx context.Context, userID int64, 
 func (svc *LndhubService) SplitIncomingPayment(ctx context.Context, captable Captable) error {
 	for user, slice := range captable.SecondaryUsers {
 		if user == captable.LeadingUserID {
-			const errMsg = "Leading user cannot be in the list of secondary users"
-			svc.Logger.Debug(errMsg)
-			return fmt.Errorf("%s", errMsg)
+			svc.Logger.Debug(responses.LeadAuthorIncludedError.Error())
+			return responses.LeadAuthorIncludedError
 		}
 		internalInvoice := models.Invoice{
 			Type:                     captable.Invoice.Type,

--- a/lib/service/invoicesubscription.go
+++ b/lib/service/invoicesubscription.go
@@ -293,7 +293,12 @@ func (svc *LndhubService) ConnectInvoiceSubscription(ctx context.Context) (lnd.S
 		return nil, err
 	}
 	// subtract 1 (read invoiceSubscriptionOptions.Addindex docs)
-	invoiceSubscriptionOptions.AddIndex = invoice.AddIndex - 1
+	if invoice.AddIndex > 0 {
+		invoiceSubscriptionOptions.AddIndex = invoice.AddIndex - 1
+	} else {
+		invoiceSubscriptionOptions.AddIndex = 0
+	}
+
 	svc.Logger.Infof("Starting invoice subscription from index: %v", invoiceSubscriptionOptions.AddIndex)
 	return svc.LndClient.SubscribeInvoices(ctx, &invoiceSubscriptionOptions)
 }

--- a/lib/service/invoicesubscription.go
+++ b/lib/service/invoicesubscription.go
@@ -101,7 +101,7 @@ func (svc *LndhubService) ProcessInvoiceUpdate(ctx context.Context, rawInvoice *
 	}
 	// Search for an incoming invoice with the r_hash that is NOT settled in our DB
 
-	err := svc.DB.NewSelect().Model(&invoice).Where("(type = ? or type = ?) AND r_hash = ? AND state <> ? AND expires_at > ?",
+	err := svc.DB.NewSelect().Model(&invoice).Where("(type = ? OR type = ?) AND r_hash = ? AND state <> ? AND expires_at > ?",
 		common.InvoiceTypeIncoming,
 		common.InvoiceTypeSubinvoice,
 		rHashStr,
@@ -197,8 +197,8 @@ func (svc *LndhubService) ProcessInvoiceUpdate(ctx context.Context, rawInvoice *
 		svc.Logger.Infof("External Payment subinvoice found, settling it.")
 		newRawInvoice := *rawInvoice
 		newRawInvoice.Memo = invoice.Memo
-		newRawInvoice.Value = invoice.Amount
-		rawInvoice.AmtPaidSat = invoice.Amount
+		newRawInvoice.Value = subInvoice.Amount
+		newRawInvoice.AmtPaidSat = subInvoice.Amount
 		dH, _ := hex.DecodeString(invoice.DescriptionHash)
 		newRawInvoice.DescriptionHash = dH
 		pI, _ := hex.DecodeString(invoice.Preimage)

--- a/lib/service/ln.go
+++ b/lib/service/ln.go
@@ -6,7 +6,7 @@ import (
 	"github.com/lightningnetwork/lnd/lnrpc"
 )
 
-//https://github.com/hsjoberg/blixt-wallet/blob/9fcc56a7dc25237bc14b85e6490adb9e044c009c/src/utils/constants.ts#L5
+// https://github.com/hsjoberg/blixt-wallet/blob/9fcc56a7dc25237bc14b85e6490adb9e044c009c/src/utils/constants.ts#L5
 const (
 	KEYSEND_CUSTOM_RECORD = 5482373484
 	TLV_WHATSAT_MESSAGE   = 34349334

--- a/lib/service/user.go
+++ b/lib/service/user.go
@@ -27,7 +27,6 @@ func (svc *LndhubService) CreateUser(ctx context.Context, login, password, nickn
 	// Check first if requested house user
 	houseUser, err := svc.FindUserByLogin(ctx, login)
 	if err == nil && houseUser.Login == svc.Config.HouseUser {
-		svc.Logger.Debugf("House user already created at %s and modified at %s with id %d", houseUser.CreatedAt.String(), houseUser.UpdatedAt.String(), houseUser.ID)
 		return &models.User{ID: houseUser.ID}, nil
 	}
 

--- a/lib/service/user.go
+++ b/lib/service/user.go
@@ -24,6 +24,12 @@ func (svc *LndhubService) CreateUser(ctx context.Context, login, password, nickn
 
 	user = &models.User{}
 
+	// Check first if requested house user
+	houseUser, err := svc.FindUserByLogin(ctx, login)
+	if err == nil && houseUser.Login == svc.Config.HouseUser {
+		return &models.User{ID: houseUser.ID}, nil
+	}
+
 	// generate user login/password if not provided
 	user.Login = login
 	if login == "" {

--- a/lib/service/user.go
+++ b/lib/service/user.go
@@ -211,3 +211,16 @@ func (svc *LndhubService) InvoicesFor(ctx context.Context, userId int64, invoice
 	}
 	return invoices, nil
 }
+
+func (svc *LndhubService) InvoicesIncomingAndInternalFor(ctx context.Context, userId int64) ([]models.Invoice, error) {
+	var invoices []models.Invoice
+
+	query := svc.DB.NewSelect().Model(&invoices).Where("user_id = ?", userId)
+	query.Where("state <> ? AND (type = ? OR type = ?)", common.InvoiceStateInitialized, common.InvoiceTypeIncoming, common.InvoiceTypeSubinvoice)
+	query.OrderExpr("id DESC").Limit(100)
+	err := query.Scan(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return invoices, nil
+}

--- a/lib/service/user.go
+++ b/lib/service/user.go
@@ -27,6 +27,7 @@ func (svc *LndhubService) CreateUser(ctx context.Context, login, password, nickn
 	// Check first if requested house user
 	houseUser, err := svc.FindUserByLogin(ctx, login)
 	if err == nil && houseUser.Login == svc.Config.HouseUser {
+		svc.Logger.Debugf("House user already created at %s and modified at %s with id %d", houseUser.CreatedAt.String(), houseUser.UpdatedAt.String(), houseUser.ID)
 		return &models.User{ID: houseUser.ID}, nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -195,7 +195,7 @@ func main() {
 	regularRateLimitPerMinMW := createRateLimitMiddleware(c.DefaultRateLimitPerMin, 1*time.Minute)
 	regularRateLimitPerSecMW := createRateLimitMiddleware(c.DefaultRateLimitPerSec, 1*time.Second)
 	tokenMW := tokens.Middleware(c.JWTSecret)
-	RegisterLegacyEndpoints(svc, e, tokenMW, strictRateLimitPerMinMW, strictRateLimitPerSecMW, regularRateLimitPerMinMW, regularRateLimitPerSecMW)
+	RegisterLegacyEndpoints(svc, e, tokenMW, strictRateLimitPerMinMW, strictRateLimitPerSecMW, regularRateLimitPerMinMW, regularRateLimitPerSecMW, tokens.AdminTokenMiddleware(c.AdminToken))
 	RegisterV2Endpoints(svc, e, tokenMW, strictRateLimitPerMinMW, strictRateLimitPerSecMW, regularRateLimitPerMinMW, regularRateLimitPerSecMW, security.SignatureMiddleware())
 
 	//Swagger API spec

--- a/main.go
+++ b/main.go
@@ -185,6 +185,10 @@ func main() {
 		IdentityPubkey: getInfo.IdentityPubkey,
 		InvoicePubSub:  service.NewPubsub(),
 	}
+	// create user collecting remainder of splitting payments
+	if _, err := svc.CreateUser(context.Background(), svc.Config.HouseUser, "", ""); err != nil {
+		e.Logger.Fatalf("Error Creating House User: %v", err)
+	}
 
 	strictRateLimitPerMinMW := createRateLimitMiddleware(c.StrictRateLimitPerMin, 1*time.Minute)
 	strictRateLimitPerSecMW := createRateLimitMiddleware(c.StrictRateLimitPerSec, 1*time.Second)

--- a/v2_endpoints.go
+++ b/v2_endpoints.go
@@ -18,7 +18,7 @@ func RegisterV2Endpoints(svc *service.LndhubService, e *echo.Echo, tokenMW, stri
 	e.GET("/v2/lnurlp/:user", v2controllers.NewLnurlController(svc).Lnurlp, strictRateLimitPerMinMW, strictRateLimitPerSecMW)
 	invoiceCtrl := v2controllers.NewInvoiceController(svc)
 	keysendCtrl := v2controllers.NewKeySendController(svc)
-	e.GET("/v2/invoice/:user", invoiceCtrl.Invoice, rateLimitPerMinMW, rateLimitPerSecMW)
+	e.GET("/v2/invoice", invoiceCtrl.Lud6Invoice, rateLimitPerMinMW, rateLimitPerSecMW)
 	secured.POST("/v2/invoices", invoiceCtrl.AddInvoice)
 	secured.GET("/v2/invoices/incoming", invoiceCtrl.GetIncomingInvoices)
 	secured.GET("/v2/invoices/outgoing", invoiceCtrl.GetOutgoingInvoices)


### PR DESCRIPTION
This PR aims to implement the splitting payments functionality inside the lndhub.
With this new functionality, a user can fetch an invoice indicating how much of the invoice and to whom is going to be split after that invoice is settled. 
One use case is multiauthor tipping when several authors contribute to a document and then that document gets tipped. The desired outcome in that case is to have an invoice that gets split in multiple once it's settled and every author gets its part. We trigger that splitting when the original invoice is paid. The other ones (sub-invoices) get automatically settled inside the lndhub accounting system.

A user can request an invoice this way `/v2/invoice?source=bafy2bzacechfogszzdyxk35nggd5udmggjmlnz5qa5oassirorr36shwssmsc&user=bahezrj4iaqacicabciqfnrov4niome6csw43r244roia35q6fiak75bmapk2zjudj3uffea,0.45&user=bahezrj4iaqacicabciqektiof7qwqp4ee3wbqew2mibgxthn7bkwr7zqvqntomi6v3bmy5q,0.48&memo=I_like_your_article&amount=1125000`
Where:
- `source=<src>` is a reference where the payment was initially generated (an article, a document section, ...)
- `user=<login>[,<pct>]` is a user login to attribute authorship. Optionally, we can specify the percentage of attribution (0-1) of this author This is optional and 1.0 is assumed if not provided. One can set multiple `user` fields
- `memo=<description>`: The regular invoice description
- `amount=<amt_msat>`: The amount in milli satoshis to be split

Then we generate as many internal invoices as authors in the request. Each internal invoice will have the total amount `amt_msat` multiplied by each author's share.  The invoice that we return to the user will be an invoice with the full amount and the payee is the house account. This account is the one collecting the payment and then distributing accordingly among authors.
Each author can view their respective invoices by calling `/v2/invoices/incoming` after they are either settled or expired/canceled.